### PR TITLE
Fix file editor navigation and remove duplicate workspace name

### DIFF
--- a/internal/server/templates/file-editor.html
+++ b/internal/server/templates/file-editor.html
@@ -127,7 +127,7 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="{{.BasePath}}/workspaces/{{.WorkspaceID}}">← Back to Workspace</a>
+                        <a class="btn btn-outline-light btn-sm" href="{{.BasePath}}/workspaces/{{.WorkspaceID}}">← Back to Workspace</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -142,8 +142,8 @@
     <div class="container-fluid mt-4">
         <div class="row">
             <div class="col-md-12">
-                <h2>File Editor</h2>
-                <p class="text-muted">Workspace: {{.WorkspaceName}} | Directory: {{.Directory}}</p>
+                <h2>File Editor - {{.WorkspaceName}}</h2>
+                <p class="text-muted">Directory: {{.Directory}}</p>
 
                 <!-- File Path Input -->
                 <div class="card mb-3">


### PR DESCRIPTION
## Summary
- Convert "Back to Workspace" link to a prominent button in navbar using Bootstrap button classes
- Combine workspace name into the main heading to eliminate duplication
- Simplify page metadata to show only the directory path

## Changes
1. **Navigation Button**: Changed the navbar link to use `btn btn-outline-light btn-sm` classes, making it more prominent and button-like
2. **Heading Update**: Changed from "File Editor" to "File Editor - {{.WorkspaceName}}" to include workspace context
3. **Metadata Simplification**: Removed duplicate workspace name from metadata line, keeping only "Directory: {{.Directory}}"

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Verify button styling in navbar looks good
- [ ] Verify workspace name appears once in heading
- [ ] Verify directory path still displays correctly

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)