### PR TITLE
Fix navbar burger button by removing Bootstrap JS dependency

### DIFF
--- a/internal/server/templates/file-editor.html
+++ b/internal/server/templates/file-editor.html
@@ -118,23 +118,12 @@
 </head>
 
 <body>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <nav class="navbar navbar-dark bg-dark">
         <div class="container-fluid">
             <a class="navbar-brand" href="{{.BasePath}}/">MobileShell</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="btn btn-outline-light btn-sm" href="{{.BasePath}}/workspaces/{{.WorkspaceID}}">← Back to Workspace</a>
-                    </li>
-                </ul>
-                <ul class="navbar-nav">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{.BasePath}}/logout">Logout</a>
-                    </li>
-                </ul>
+            <div class="d-flex gap-2">
+                <a class="btn btn-outline-light btn-sm" href="{{.BasePath}}/workspaces/{{.WorkspaceID}}">← Back to Workspace</a>
+                <a class="btn btn-outline-light btn-sm" href="{{.BasePath}}/logout">Logout</a>
             </div>
         </div>
     </nav>
@@ -184,7 +173,6 @@
         </div>
     </div>
 
-    <script src="{{.BasePath}}/static/static/bootstrap.bundle.min.js"></script>
     <script>
         (function() {
             const filePathInput = document.getElementById('file_path');


### PR DESCRIPTION
## Summary
- Remove navbar-toggler (burger button) that required Bootstrap JS
- Simplify navbar to match workspaces.html pattern using flexbox
- Remove non-existent bootstrap.bundle.min.js script reference
- Change Logout link to button style for consistency

## Problem
The burger button (navbar-toggler) in the file editor page didn't work because:
1. Bootstrap JS file (bootstrap.bundle.min.js) doesn't exist in the static directory
2. No other templates in the project use Bootstrap JS
3. The project is designed to work without JavaScript dependencies

## Solution
This PR aligns the file editor navbar with the design pattern used in `workspaces.html`:
- Uses flexbox layout instead of Bootstrap collapse components
- Removes all Bootstrap JS-dependent features
- Keeps the navbar fully functional without requiring JavaScript

## Changes
- Removed `navbar-expand-lg` and collapse functionality
- Replaced `<ul class="navbar-nav">` structure with simple `<div class="d-flex gap-2">`
- Converted Logout link to button style (`btn btn-outline-light btn-sm`)
- Removed `<script src="{{.BasePath}}/static/static/bootstrap.bundle.min.js"></script>` tag

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Navbar displays correctly without JavaScript errors
- [x] Back to Workspace button works
- [x] Logout button works
- [x] Layout is responsive with Bootstrap's utility classes

Related to #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)