### PR TITLE
Add multi-line pre-command support with automatic shebang handling

### DIFF
--- a/internal/server/templates/edit-workspace.html
+++ b/internal/server/templates/edit-workspace.html
@@ -46,9 +46,8 @@
                             </div>
                             <div class="mb-3">
                                 <label for="pre_command" class="form-label">Pre-command (optional)</label>
-                                <input type="text" class="form-control" id="pre_command" name="pre_command"
-                                    value="{{.Workspace.PreCommand}}" placeholder="e.g., source .env">
-                                <div class="form-text">This command runs before every command in this workspace</div>
+                                <textarea class="form-control" id="pre_command" name="pre_command" rows="4" placeholder="e.g., source .env">{{.Workspace.PreCommand}}</textarea>
+                                <div class="form-text">This command runs before every command in this workspace. Supports multi-line scripts. If no shebang is provided, #!/usr/bin/env bash is added automatically.</div>
                             </div>
                             <div class="d-flex justify-content-between">
                                 <div>

--- a/internal/server/templates/hx-workspace-form.html
+++ b/internal/server/templates/hx-workspace-form.html
@@ -15,8 +15,8 @@
         </div>
         <div class="mb-3">
             <label for="pre_command" class="form-label">Pre-command (optional)</label>
-            <input type="text" class="form-control" id="pre_command" name="pre_command" value="{{.FormValues.PreCommand}}" placeholder="e.g., source .env">
-            <div class="form-text">This command runs before every command in this workspace</div>
+            <textarea class="form-control" id="pre_command" name="pre_command" rows="4" placeholder="e.g., source .env">{{.FormValues.PreCommand}}</textarea>
+            <div class="form-text">This command runs before every command in this workspace. Supports multi-line scripts. If no shebang is provided, #!/usr/bin/env bash is added automatically.</div>
         </div>
         <button type="submit" class="btn btn-primary">Create Workspace</button>
     </form>

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -36,8 +36,9 @@ func TestWorkspaceCreation(t *testing.T) {
 		t.Errorf("Expected directory '%s', got '%s'", workDir, ws.Directory)
 	}
 
-	if ws.PreCommand != "source .env" {
-		t.Errorf("Expected pre-command 'source .env', got '%s'", ws.PreCommand)
+	expectedPreCommand := "#!/usr/bin/env bash\nsource .env"
+	if ws.PreCommand != expectedPreCommand {
+		t.Errorf("Expected pre-command '%s', got '%s'", expectedPreCommand, ws.PreCommand)
 	}
 
 	// Verify workspace directory exists

--- a/scripts/jsdom-test-parallel.mjs
+++ b/scripts/jsdom-test-parallel.mjs
@@ -426,11 +426,11 @@ async function testWorkspaceEditing() {
   const editPageDoc = parseHTML(editPageResponse.text);
   const nameInput = editPageDoc.querySelector('input[name="name"]');
   const directoryInput = editPageDoc.querySelector('input[name="directory"]');
-  const preCommandInput = editPageDoc.querySelector('input[name="pre_command"]');
+  const preCommandInput = editPageDoc.querySelector('textarea[name="pre_command"]');
 
   assert.ok(nameInput, 'Should have name input field');
   assert.ok(directoryInput, 'Should have directory input field');
-  assert.ok(preCommandInput, 'Should have pre-command input field');
+  assert.ok(preCommandInput, 'Should have pre-command textarea field');
   assert.equal(nameInput.value, workspaceName, 'Name field should have current name');
 
   // Update the workspace


### PR DESCRIPTION
Implements issue #12 by adding support for multi-line pre-commands with automatic shebang detection and shell selection.

Changes:
- Add automatic shebang normalization: prepends #!/usr/bin/env bash to pre-commands that don't have a shebang
- Support custom shells via shebang (e.g., #!/usr/bin/env fish)
- Execute pre-commands as sourced scripts to preserve environment
- Change pre-command input from text field to textarea in UI
- Extract shell from shebang to use correct shell for execution

The pre-command is now written to a script file and sourced (not executed) to ensure environment variables carry over to the user's command. The shell is automatically detected from the shebang line.