### PR TITLE
Add file browser for all local files (fixes #96)

### DIFF
--- a/internal/server/templates/file-browser.html
+++ b/internal/server/templates/file-browser.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MobileShell - File Browser</title>
+    <link href="{{.BasePath}}/static/static/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .file-table {
+            font-size: 0.9rem;
+        }
+        .file-table td {
+            vertical-align: middle;
+        }
+        .file-name {
+            font-family: monospace;
+        }
+        .file-icon {
+            margin-right: 0.5rem;
+        }
+        .directory-icon {
+            color: #0d6efd;
+        }
+        .file-icon-regular {
+            color: #6c757d;
+        }
+        .breadcrumb {
+            background-color: #f8f9fa;
+            padding: 0.75rem 1rem;
+            border-radius: 0.25rem;
+        }
+        .permissions {
+            font-family: monospace;
+            font-size: 0.85rem;
+        }
+        .file-size {
+            text-align: right;
+        }
+    </style>
+</head>
+
+<body>
+    <nav class="navbar navbar-dark bg-dark">
+        <div class="container-fluid">
+            <span class="navbar-brand mb-0 h1">MobileShell - File Browser</span>
+            <a href="{{.BasePath}}/logout" class="btn btn-outline-light btn-sm">Logout</a>
+        </div>
+    </nav>
+
+    <div class="container-fluid mt-4">
+        <div class="mb-3">
+            <a href="{{.BasePath}}/" class="btn btn-sm btn-outline-secondary">&larr; Back to Workspaces</a>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">Directory: {{.Path}}</h5>
+            </div>
+            <div class="card-body">
+                <nav aria-label="breadcrumb" class="mb-3">
+                    <ol class="breadcrumb mb-0">
+                        <li class="breadcrumb-item"><a href="{{.BasePath}}/files?path=/">Root</a></li>
+                        {{if ne .Path "/"}}
+                        {{$basePath := .BasePath}}
+                        {{$parts := split .Path "/"}}
+                        {{$currentPath := ""}}
+                        {{range $index, $part := $parts}}
+                        {{if ne $part ""}}
+                        {{$currentPath = printf "%s/%s" $currentPath $part}}
+                        <li class="breadcrumb-item"><a href="{{$basePath}}/files?path={{$currentPath}}">{{$part}}</a></li>
+                        {{end}}
+                        {{end}}
+                        {{end}}
+                    </ol>
+                </nav>
+
+                {{if .ParentDir}}
+                <div class="mb-2">
+                    <a href="{{.BasePath}}/files?path={{.ParentDir}}" class="btn btn-sm btn-outline-primary">&uarr; Parent Directory</a>
+                </div>
+                {{end}}
+
+                <table class="table table-hover file-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Size</th>
+                            <th>Modified</th>
+                            <th>Owner</th>
+                            <th>Permissions</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{range .Files}}
+                        <tr>
+                            <td class="file-name">
+                                {{if .IsDir}}
+                                <span class="file-icon directory-icon">&#128193;</span>
+                                <a href="{{$.BasePath}}/files?path={{.Path}}">{{.Name}}/</a>
+                                {{else}}
+                                <span class="file-icon file-icon-regular">&#128196;</span>
+                                <a href="{{.ViewURL}}">{{.Name}}</a>
+                                {{end}}
+                            </td>
+                            <td class="file-size">
+                                {{if not .IsDir}}
+                                {{if lt .Size 1024}}
+                                {{.Size}} B
+                                {{else if lt .Size 1048576}}
+                                {{printf "%.1f" (divf .Size 1024.0)}} KB
+                                {{else if lt .Size 1073741824}}
+                                {{printf "%.1f" (divf .Size 1048576.0)}} MB
+                                {{else}}
+                                {{printf "%.1f" (divf .Size 1073741824.0)}} GB
+                                {{end}}
+                                {{else}}
+                                -
+                                {{end}}
+                            </td>
+                            <td>{{.ModTime.Format "2006-01-02 15:04:05 UTC"}}</td>
+                            <td>{{.Owner}}</td>
+                            <td class="permissions">{{.Mode}}</td>
+                            <td>
+                                {{if not .IsDir}}
+                                <a href="{{.ViewURL}}" class="btn btn-sm btn-outline-info">View</a>
+                                <a href="{{.DownloadURL}}" class="btn btn-sm btn-outline-primary" download>Download</a>
+                                {{end}}
+                            </td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <script src="{{.BasePath}}/static/static/htmx.min.js"></script>
+</body>
+
+</html>

--- a/internal/server/templates/file-view.html
+++ b/internal/server/templates/file-view.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MobileShell - View File</title>
+    <link href="{{.BasePath}}/static/static/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .file-content {
+            background: #f8f9fa;
+            padding: 1rem;
+            border-radius: 4px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            max-height: none;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+
+<body>
+    <nav class="navbar navbar-dark bg-dark">
+        <div class="container-fluid">
+            <span class="navbar-brand mb-0 h1">MobileShell - File Viewer</span>
+            <a href="{{.BasePath}}/logout" class="btn btn-outline-light btn-sm">Logout</a>
+        </div>
+    </nav>
+
+    <div class="container-fluid mt-4">
+        <div class="mb-3">
+            <a href="{{.DirURL}}" class="btn btn-sm btn-outline-secondary">&larr; Back to Directory</a>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">File: {{.Path}}</h5>
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <strong>Size:</strong> {{.Size}} bytes<br>
+                    <strong>Modified:</strong> {{.ModTime.Format "2006-01-02 15:04:05 UTC"}}
+                </div>
+
+                <div class="mb-3">
+                    <a href="{{.BasePath}}/files/download?path={{.Path}}" class="btn btn-sm btn-outline-primary" download>Download</a>
+                </div>
+
+                <h6>Content:</h6>
+                <div class="file-content">{{.Content}}</div>
+            </div>
+        </div>
+    </div>
+
+    <script src="{{.BasePath}}/static/static/htmx.min.js"></script>
+</body>
+
+</html>

--- a/internal/server/templates/process.html
+++ b/internal/server/templates/process.html
@@ -69,7 +69,7 @@
 
                 <p class="card-text">
                     <strong>Command:</strong> <code>{{.Process.Command}}</code><br>
-                    <strong>Process ID:</strong> {{.Process.ID}}<br>
+                    <strong>Process ID:</strong> <a href="{{.ProcessDirURL}}">{{.Process.ID}}</a><br>
                     <strong>PID:</strong> {{.Process.PID}}<br>
                     <strong>Started:</strong> {{.Process.StartTime.Format "2006-01-02 15:04:05 UTC"}}
                     {{if .Process.Completed}}


### PR DESCRIPTION
## Summary

This PR implements the file browser feature requested in #96:

- **File browser for all local files**: Added `/files` endpoint that can browse any local files on the system (not restricted to workspace directories)
- **Rich directory listings**: Shows file name, size, modification time, owner, and permissions
- **File actions**: Each file has links to view and download
- **Directory navigation**: Breadcrumb navigation and parent directory links for easy browsing
- **Process ID links**: Process IDs in process detail pages now link to the corresponding directory in StateDir for easy access to process files

## Implementation Details

- Added three new handlers: `handleFileBrowser`, `handleFileView`, and `handleFileDownload`
- Created two new templates: `file-browser.html` and `file-view.html`
- Updated `process.html` template to make Process ID clickable, linking to the process directory
- Added template helper functions for string splitting and float division
- All changes follow existing code patterns and conventions

## Test plan

- [x] All existing tests pass (`./scripts/test.sh`)
- [x] File browser accessible at `/files`
- [x] Directory listings display correctly with all file information
- [x] File view and download work as expected
- [x] Process ID links navigate to correct directories
- [x] Breadcrumb navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)