### PR TITLE
Fix Claude integration markdown rendering

### DIFF
--- a/internal/claude/parser.go
+++ b/internal/claude/parser.go
@@ -1,0 +1,57 @@
+package claude
+
+import (
+	"bufio"
+	"encoding/json"
+	"strings"
+)
+
+// StreamEvent represents a single event in Claude's stream-json output
+type StreamEvent struct {
+	Type    string          `json:"type"`
+	Message *MessageContent `json:"message,omitempty"`
+}
+
+// MessageContent represents the message field in assistant events
+type MessageContent struct {
+	Content []ContentBlock `json:"content"`
+}
+
+// ContentBlock represents a single content block (text, tool use, etc.)
+type ContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// ParseStreamJSON parses Claude's stream-json output and extracts text content
+// It returns the extracted markdown text from all assistant messages
+func ParseStreamJSON(streamOutput string) string {
+	var textParts []string
+	scanner := bufio.NewScanner(strings.NewReader(streamOutput))
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// Each line should be a JSON event
+		var event StreamEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			// Not valid JSON, skip this line
+			continue
+		}
+
+		// Extract text from assistant messages
+		if event.Type == "assistant" && event.Message != nil {
+			for _, block := range event.Message.Content {
+				if block.Type == "text" && block.Text != "" {
+					textParts = append(textParts, block.Text)
+				}
+			}
+		}
+	}
+
+	// Join all text parts
+	return strings.Join(textParts, "\n\n")
+}

--- a/internal/claude/parser_test.go
+++ b/internal/claude/parser_test.go
@@ -1,0 +1,60 @@
+package claude
+
+import (
+	"testing"
+)
+
+func TestParseStreamJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "single assistant message",
+			input: `{"type":"system","subtype":"init","session_id":"test"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Hello, world!"}]}}
+{"type":"result","subtype":"success"}`,
+			expected: "Hello, world!",
+		},
+		{
+			name: "multiple assistant messages",
+			input: `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"First message"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Second message"}]}}
+{"type":"result","subtype":"success"}`,
+			expected: "First message\n\nSecond message",
+		},
+		{
+			name: "markdown content",
+			input: `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"# Hello\n\nThis is **bold** text."}]}}`,
+			expected: "# Hello\n\nThis is **bold** text.",
+		},
+		{
+			name: "mixed content with non-text blocks",
+			input: `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Here is some text"},{"type":"tool_use","id":"123"},{"type":"text","text":"More text"}]}}`,
+			expected: "Here is some text\n\nMore text",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no assistant messages",
+			input:    `{"type":"system","subtype":"init"}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseStreamJSON(tt.input)
+			if result != tt.expected {
+				t.Errorf("ParseStreamJSON() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #112

## Summary

Claude integration now properly renders markdown instead of showing raw stream-json output.

## Changes

1. **Added stream-json parser** (`internal/claude/parser.go`):
   - Parses Claude CLI stream-json output format
   - Extracts text content from assistant messages

2. **Post-process Claude output** (`internal/nohup/nohup.go`):
   - Detects Claude commands after completion
   - Extracts markdown from stream-json
   - Rewrites output as clean markdown
   - Sets output-type to "markdown" for proper HTML rendering

3. **Updated tests** (`scripts/jsdom-test-parallel.mjs`):
   - Mock Claude outputs stream-json format
   - Verifies markdown rendering with HTML elements

## How It Works

**Before**: Raw JSON stream with ANSI codes
```json
{"type":"system","subtype":"init",...}
{"type":"assistant","message":{"content":[...]}}
```

**After**: Beautiful markdown rendered as HTML with headers, lists, bold text, etc.

## Test Results

✅ All Go tests pass
✅ All jsdom tests pass
✅ Mock and real Claude CLI both work correctly