### PR TITLE
Correct Sysmon: select processes by name and bulk actions

### DIFF
--- a/internal/server/templates/hx-sysmon-processes.html
+++ b/internal/server/templates/hx-sysmon-processes.html
@@ -2,27 +2,28 @@
 <table class="table table-striped table-hover process-table">
     <thead>
         <tr>
-            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=pid&order={{if eq .SortBy "pid"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}asc{{end}}"
+            <th style="width: 40px;"></th>
+            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=pid&order={{if eq .SortBy "pid"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}asc{{end}}&search={{.Search}}"
                 hx-target="#process-list"
                 hx-swap="innerHTML">
                 PID {{if eq .SortBy "pid"}}<span class="sort-indicator">{{if eq .Order "asc"}}▲{{else}}▼{{end}}</span>{{end}}
             </th>
-            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=name&order={{if eq .SortBy "name"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}asc{{end}}"
+            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=name&order={{if eq .SortBy "name"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}asc{{end}}&search={{.Search}}"
                 hx-target="#process-list"
                 hx-swap="innerHTML">
                 Name {{if eq .SortBy "name"}}<span class="sort-indicator">{{if eq .Order "asc"}}▲{{else}}▼{{end}}</span>{{end}}
             </th>
-            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=cpu&order={{if eq .SortBy "cpu"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}desc{{end}}"
+            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=cpu&order={{if eq .SortBy "cpu"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}desc{{end}}&search={{.Search}}"
                 hx-target="#process-list"
                 hx-swap="innerHTML">
                 CPU% {{if eq .SortBy "cpu"}}<span class="sort-indicator">{{if eq .Order "asc"}}▲{{else}}▼{{end}}</span>{{end}}
             </th>
-            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=memory&order={{if eq .SortBy "memory"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}desc{{end}}"
+            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=memory&order={{if eq .SortBy "memory"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}desc{{end}}&search={{.Search}}"
                 hx-target="#process-list"
                 hx-swap="innerHTML">
                 Memory {{if eq .SortBy "memory"}}<span class="sort-indicator">{{if eq .Order "asc"}}▲{{else}}▼{{end}}</span>{{end}}
             </th>
-            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=io&order={{if eq .SortBy "io"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}desc{{end}}"
+            <th hx-get="{{$.BasePath}}/sysmon/hx-processes?sort=io&order={{if eq .SortBy "io"}}{{if eq .Order "asc"}}desc{{else}}asc{{end}}{{else}}desc{{end}}&search={{.Search}}"
                 hx-target="#process-list"
                 hx-swap="innerHTML">
                 I/O {{if eq .SortBy "io"}}<span class="sort-indicator">{{if eq .Order "asc"}}▲{{else}}▼{{end}}</span>{{end}}
@@ -33,6 +34,7 @@
     <tbody>
         {{range .Processes}}
         <tr>
+            <td><input type="checkbox" class="form-check-input process-checkbox" value="{{.PID}}"></td>
             <td><a href="{{$.BasePath}}/sysmon/process/{{.PID}}">{{.PID}}</a></td>
             <td>{{.Name}}</td>
             <td class="{{if gt .CPUPercent 50.0}}cpu-high{{else if gt .CPUPercent 20.0}}cpu-medium{{end}}">

--- a/internal/server/templates/sysmon.html
+++ b/internal/server/templates/sysmon.html
@@ -64,15 +64,43 @@
     </nav>
 
     <div class="container-fluid mt-4">
+        <div id="alert-container"></div>
         <div class="card">
             <div class="card-body">
                 <h5 class="card-title">System Monitor - My Processes</h5>
                 <p class="text-muted small mb-3">Showing processes owned by current user. Auto-refresh every 2 seconds.</p>
 
+                <div class="d-flex gap-2 mb-3">
+                    <input type="text" class="form-control" id="process-search" name="search" 
+                           placeholder="Filter processes (e.g. 'python script')..."
+                           hx-get="{{.BasePath}}/sysmon/hx-processes?sort={{.SortBy}}&order={{.Order}}"
+                           hx-trigger="keyup changed delay:500ms"
+                           hx-target="#process-list"
+                           hx-include="[name='search']">
+                    
+                    <div class="dropdown">
+                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="bulkActions" data-bs-toggle="dropdown" aria-expanded="false">
+                            Actions
+                        </button>
+                        <ul class="dropdown-menu shadow" aria-labelledby="bulkActions">
+                            <li><h6 class="dropdown-header">Send Signal to Selected</h6></li>
+                            <li><button class="dropdown-item" onclick="sendBulkSignal(15)">SIGTERM (15)</button></li>
+                            <li><button class="dropdown-item" onclick="sendBulkSignal(9)">SIGKILL (9)</button></li>
+                            <li><button class="dropdown-item" onclick="sendBulkSignal(2)">SIGINT (2)</button></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="select-all-processes" onchange="toggleAllProcesses(this)">
+                    <label class="form-check-label" for="select-all-processes">Select All</label>
+                </div>
+
                 <div id="process-list"
                      hx-get="{{.BasePath}}/sysmon/hx-processes?sort={{.SortBy}}&order={{.Order}}"
                      hx-trigger="load, every 2s"
-                     hx-swap="innerHTML">
+                     hx-swap="innerHTML"
+                     hx-include="[name='search']">
                     <div class="text-center py-5">
                         <div class="spinner-border text-primary" role="status">
                             <span class="visually-hidden">Loading...</span>
@@ -83,6 +111,66 @@
             </div>
         </div>
     </div>
+
+    <script>
+        function toggleAllProcesses(checkbox) {
+            const checkboxes = document.querySelectorAll('.process-checkbox');
+            checkboxes.forEach(cb => {
+                cb.checked = checkbox.checked;
+            });
+        }
+
+        function sendBulkSignal(signal) {
+            const selected = Array.from(document.querySelectorAll('.process-checkbox:checked'))
+                .map(cb => cb.value);
+            
+            if (selected.length === 0) {
+                alert('No processes selected');
+                return;
+            }
+
+            if (!confirm(`Send signal ${signal} to ${selected.length} processes?`)) {
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append('signal', signal);
+            selected.forEach(pid => formData.append('pids', pid));
+
+            fetch('{{.BasePath}}/sysmon/hx-bulk-signal', {
+                method: 'POST',
+                body: formData
+            }).then(response => response.text())
+              .then(html => {
+                  const alertContainer = document.getElementById('alert-container');
+                  alertContainer.innerHTML = html;
+                  // Refresh process list immediately
+                  htmx.trigger('#process-search', 'changed');
+              })
+              .catch(error => {
+                  console.error('Error sending bulk signal:', error);
+                  alert('Failed to send signal');
+              });
+        }
+
+        // Preserve selections across HTMX updates
+        document.body.addEventListener('htmx:beforeSwap', function(evt) {
+            if (evt.detail.target.id === 'process-list') {
+                const selectedPids = Array.from(document.querySelectorAll('.process-checkbox:checked'))
+                    .map(cb => cb.value);
+                evt.detail.selectedPids = selectedPids;
+            }
+        });
+
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            if (evt.detail.target.id === 'process-list' && evt.detail.selectedPids) {
+                evt.detail.selectedPids.forEach(pid => {
+                    const cb = document.querySelector(`.process-checkbox[value="${pid}"]`);
+                    if (cb) cb.checked = true;
+                });
+            }
+        });
+    </script>
 </body>
 
 </html>

--- a/internal/sysmon/filter_test.go
+++ b/internal/sysmon/filter_test.go
@@ -1,0 +1,32 @@
+package sysmon
+
+import (
+	"testing"
+)
+
+func TestMatchesSearch(t *testing.T) {
+	tests := []struct {
+		text     string
+		query    string
+		expected bool
+	}{
+		{"python script.py", "python", true},
+		{"python script.py", "PYTHON", true},
+		{"python script.py", "script", true},
+		{"python script.py", "python script", true},
+		{"python script.py", "script python", true},
+		{"python script.py", "go", false},
+		{"python script.py", "python go", false},
+		{"bash", "", true},
+		{"bash", "  ", true},
+		{"/usr/bin/python3 main.py", "python main", true},
+		{"/usr/bin/python3 main.py", "bin python3", true},
+	}
+
+	for _, tt := range tests {
+		result := matchesSearch(tt.text, tt.query)
+		if result != tt.expected {
+			t.Errorf("matchesSearch(%q, %q) = %v; want %v", tt.text, tt.query, result, tt.expected)
+		}
+	}
+}

--- a/internal/sysmon/routes.go
+++ b/internal/sysmon/routes.go
@@ -29,4 +29,8 @@ func RegisterRoutes(
 	mux.HandleFunc("/sysmon/process/{pid}/hx-signal", authMiddleware(wrapHandler(func(ctx context.Context, r *http.Request) ([]byte, error) {
 		return HandleSendSignal(ctx, r, r.PathValue("pid"))
 	})))
+
+	mux.HandleFunc("/sysmon/hx-bulk-signal", authMiddleware(wrapHandler(func(ctx context.Context, r *http.Request) ([]byte, error) {
+		return HandleBulkSignal(ctx, r)
+	})))
 }


### PR DESCRIPTION
Fixes #114 by correctly implementing features in the Sysmon section:
- Search filtering for processes (multi-word support)
- Checkboxes for process selection
- Bulk signal sending (SIGTERM, SIGKILL, SIGINT)
- Selection preservation during auto-refresh