### PR TITLE
Fix flaky TestNohupRunWithStderrOutput test

### DIFF
--- a/internal/nohup/nohup_test.go
+++ b/internal/nohup/nohup_test.go
@@ -286,23 +286,35 @@ func TestNohupRunWithStderrOutput(t *testing.T) {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}
 
-	// Give it a moment to complete
-	time.Sleep(100 * time.Millisecond)
-
-	// Verify output.log contains both stdout and stderr with proper prefixes
+	// Poll for expected output with timeout
 	processDir := workspace.GetProcessDir(ws, hash)
 	outputFile := filepath.Join(processDir, "output.log")
-	outputData, err := os.ReadFile(outputFile)
-	if err != nil {
-		t.Fatalf("Failed to read output.log: %v", err)
-	}
 
-	output := string(outputData)
-	if !contains(output, "stdout") || !contains(output, "stdout message") {
-		t.Errorf("Expected output to contain 'stdout' and 'stdout message', got '%s'", output)
-	}
-	if !contains(output, "stderr") || !contains(output, "stderr message") {
-		t.Errorf("Expected output to contain 'stderr' and 'stderr message', got '%s'", output)
+	timeout := time.After(2 * time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+
+	var output string
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("Timeout waiting for output, got '%s'", output)
+		case <-ticker.C:
+			outputData, err := os.ReadFile(outputFile)
+			if err != nil {
+				continue // File might not exist yet
+			}
+			output = string(outputData)
+
+			// Check if we have all expected output
+			hasStdout := contains(output, "stdout") && contains(output, "stdout message")
+			hasStderr := contains(output, "stderr") && contains(output, "stderr message")
+
+			if hasStdout && hasStderr {
+				// Success! Found all expected output
+				return
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed flaky `TestNohupRunWithStderrOutput` test using a polling loop instead of fixed sleep
- Polls for expected output with 5ms intervals and 2s timeout
- Faster (completes in ~20ms instead of 100ms+) and more reliable

## Test plan
- Ran `TestNohupRunWithStderrOutput` 10 times consecutively - all passed
- Ran all nohup tests - all passed

## Context
The test was flaky because it read the output.log file immediately after Run() returned. While the Run() function waits for all readers and writers to complete, there could still be a race where stderr output wasn't fully readable from the file system.

The fix uses a polling loop that checks for the expected output every 5ms with a 2s timeout. This is both faster and more reliable than a fixed sleep since it actually verifies the content is present before continuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)