### PR TITLE
Remove unused commandArgs parameter from nohup.Run()

### DIFF
--- a/cmd/mobileshell/main.go
+++ b/cmd/mobileshell/main.go
@@ -110,7 +110,7 @@ var nohupCmd = &cobra.Command{
 		workspaceTimestamp := args[0]
 		processHash := args[1]
 
-		return nohup.Run(dir, workspaceTimestamp, processHash, args[2:])
+		return nohup.Run(dir, workspaceTimestamp, processHash)
 	},
 }
 

--- a/internal/nohup/issue20_test.go
+++ b/internal/nohup/issue20_test.go
@@ -59,7 +59,7 @@ exit 0
 	// Run the nohup process
 	runDone := make(chan error, 1)
 	go func() {
-		runDone <- Run(stateDir, ws.ID, hash, []string{"sh", scriptPath})
+		runDone <- Run(stateDir, ws.ID, hash)
 	}()
 
 	// Give the process some time to start and output the prompt
@@ -219,7 +219,7 @@ exit 0
 	// Run the nohup process
 	runDone := make(chan error, 1)
 	go func() {
-		runDone <- Run(stateDir, ws.ID, hash, []string{"sh", scriptPath})
+		runDone <- Run(stateDir, ws.ID, hash)
 	}()
 
 	// Check output at different time points

--- a/internal/nohup/nohup.go
+++ b/internal/nohup/nohup.go
@@ -22,7 +22,7 @@ import (
 
 // Run executes a command in nohup mode within a workspace
 // This function is called by the `mobileshell nohup` command
-func Run(stateDir, workspaceTimestamp, processHash string, commandArgs []string) error {
+func Run(stateDir, workspaceTimestamp, processHash string) error {
 	// Get the workspace
 	ws, err := workspace.GetWorkspace(stateDir, workspaceTimestamp)
 	if err != nil {

--- a/internal/nohup/nohup_test.go
+++ b/internal/nohup/nohup_test.go
@@ -39,7 +39,7 @@ func TestNohupRun(t *testing.T) {
 	workspaceTS := filepath.Base(ws.Path)
 
 	// Run the nohup command
-	err = Run(tmpDir, workspaceTS, hash, []string{})
+	err = Run(tmpDir, workspaceTS, hash)
 	if err != nil {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestNohupRunWithPreCommand(t *testing.T) {
 	workspaceTS := filepath.Base(ws.Path)
 
 	// Run the nohup command
-	err = Run(tmpDir, workspaceTS, hash, []string{})
+	err = Run(tmpDir, workspaceTS, hash)
 	if err != nil {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestNohupRunWithFailingCommand(t *testing.T) {
 	workspaceTS := filepath.Base(ws.Path)
 
 	// Run the nohup command
-	err = Run(tmpDir, workspaceTS, hash, []string{})
+	err = Run(tmpDir, workspaceTS, hash)
 	if err != nil {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestNohupRunWithWorkingDirectory(t *testing.T) {
 	workspaceTS := filepath.Base(ws.Path)
 
 	// Run the nohup command
-	err = Run(tmpDir, workspaceTS, hash, []string{})
+	err = Run(tmpDir, workspaceTS, hash)
 	if err != nil {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestNohupRunWithStderrOutput(t *testing.T) {
 	// Run the nohup command in background to avoid blocking
 	done := make(chan error, 1)
 	go func() {
-		done <- Run(tmpDir, workspaceTS, hash, []string{})
+		done <- Run(tmpDir, workspaceTS, hash)
 	}()
 
 	// Poll for expected output with timeout
@@ -391,7 +391,7 @@ func TestNohupRunWithStdin(t *testing.T) {
 	// Start nohup in background
 	done := make(chan error)
 	go func() {
-		done <- Run(tmpDir, workspaceTS, hash, []string{})
+		done <- Run(tmpDir, workspaceTS, hash)
 	}()
 
 	// Wait for process to start

--- a/internal/nohup/tty_test.go
+++ b/internal/nohup/tty_test.go
@@ -36,7 +36,7 @@ func TestTTYSupport(t *testing.T) {
 	workspaceTS := filepath.Base(ws.Path)
 
 	// Run the nohup command
-	err = Run(tmpDir, workspaceTS, hash, []string{})
+	err = Run(tmpDir, workspaceTS, hash)
 	if err != nil {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestTTYEcho(t *testing.T) {
 	// Start nohup in background
 	done := make(chan error)
 	go func() {
-		done <- Run(tmpDir, workspaceTS, hash, []string{})
+		done <- Run(tmpDir, workspaceTS, hash)
 	}()
 
 	// Wait for process to start by polling for PID file
@@ -184,7 +184,7 @@ func TestColorOutput(t *testing.T) {
 	workspaceTS := filepath.Base(ws.Path)
 
 	// Run the nohup command
-	err = Run(tmpDir, workspaceTS, hash, []string{})
+	err = Run(tmpDir, workspaceTS, hash)
 	if err != nil {
 		t.Fatalf("Failed to run nohup: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Remove unused `commandArgs` parameter from `nohup.Run()` function
- The parameter was never used in the function body
- Since nohup command uses `Args: cobra.ExactArgs(2)`, the `args[2:]` slice would always be empty
- Update all call sites (main.go and all test files) to match new signature

## Changes
- `internal/nohup/nohup.go`: Remove `commandArgs` parameter from `Run()` signature
- `cmd/mobileshell/main.go`: Remove `args[2:]` from `Run()` call
- Test files: Remove empty `[]string{}` parameter from all test calls

## Test plan
- ✅ All tests passing via `./scripts/test.sh`
- ✅ Verified no other call sites exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)