### PR TITLE
Show detailed explanation when nohup subcommand is called without args

### DIFF
--- a/cmd/mobileshell/main.go
+++ b/cmd/mobileshell/main.go
@@ -96,7 +96,7 @@ var addPasswordCmd = &cobra.Command{
 }
 
 var nohupCmd = &cobra.Command{
-	Use:   "nohup WORKSPACE_TIMESTAMP PROCESS_HASH",
+	Use:   "nohup WORKSPACE_ID PROCESS_HASH",
 	Short: "Execute a process in nohup mode (internal use)",
 	Long: `Execute a process in nohup mode within a workspace.
 
@@ -105,8 +105,8 @@ in detached mode (nohup). It handles process execution, output capture,
 and maintains process state in the workspace directory.
 
 Arguments:
-  WORKSPACE_TIMESTAMP  The timestamp identifier of the workspace
-  PROCESS_HASH        The hash identifier of the process to execute
+  WORKSPACE_ID    The unique identifier of the workspace (URL-safe ID)
+  PROCESS_HASH    The hash identifier of the process to execute
 
 This command should not be called directly by users. It is automatically
 invoked by the server when executing processes in nohup mode.`,
@@ -126,10 +126,10 @@ invoked by the server when executing processes in nohup mode.`,
 			return err
 		}
 
-		workspaceTimestamp := args[0]
+		workspaceID := args[0]
 		processHash := args[1]
 
-		return nohup.Run(dir, workspaceTimestamp, processHash)
+		return nohup.Run(dir, workspaceID, processHash)
 	},
 }
 

--- a/cmd/mobileshell/main.go
+++ b/cmd/mobileshell/main.go
@@ -96,11 +96,30 @@ var addPasswordCmd = &cobra.Command{
 }
 
 var nohupCmd = &cobra.Command{
-	Use:    "nohup WORKSPACE_TIMESTAMP PROCESS_HASH",
-	Short:  "Execute a process in nohup mode (internal use)",
-	Long:   `Execute a process in nohup mode within a workspace. This command is used internally by the server.`,
+	Use:   "nohup WORKSPACE_TIMESTAMP PROCESS_HASH",
+	Short: "Execute a process in nohup mode (internal use)",
+	Long: `Execute a process in nohup mode within a workspace.
+
+This command is used internally by the MobileShell server to run processes
+in detached mode (nohup). It handles process execution, output capture,
+and maintains process state in the workspace directory.
+
+Arguments:
+  WORKSPACE_TIMESTAMP  The timestamp identifier of the workspace
+  PROCESS_HASH        The hash identifier of the process to execute
+
+This command should not be called directly by users. It is automatically
+invoked by the server when executing processes in nohup mode.`,
 	Hidden: true, // Hide from help since it's for internal use
-	Args:   cobra.ExactArgs(2),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(2)(cmd, args); err != nil {
+			// Show the long description when args are missing
+			cmd.Println(cmd.Long)
+			cmd.Println()
+			return err
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dir, err := server.GetStateDir(stateDir, false)
 		if err != nil {

--- a/internal/nohup/nohup.go
+++ b/internal/nohup/nohup.go
@@ -22,9 +22,9 @@ import (
 
 // Run executes a command in nohup mode within a workspace
 // This function is called by the `mobileshell nohup` command
-func Run(stateDir, workspaceTimestamp, processHash string) error {
+func Run(stateDir, workspaceID, processHash string) error {
 	// Get the workspace
-	ws, err := workspace.GetWorkspace(stateDir, workspaceTimestamp)
+	ws, err := workspace.GetWorkspace(stateDir, workspaceID)
 	if err != nil {
 		return fmt.Errorf("failed to get workspace: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Improve error messages when the `nohup` subcommand is called with incorrect arguments
- Shows detailed explanation of what the command does before the error message
- Helps users understand that this is an internal command not meant for direct use

## Changes
- Expand the `Long` description with detailed information about:
  - Purpose: internal command for MobileShell server
  - Required arguments and their meaning
  - Note that users should not call it directly
- Add custom `Args` validator that displays the Long description when argument validation fails

## Example Output
When called without arguments:
```
Execute a process in nohup mode within a workspace.

This command is used internally by the MobileShell server to run processes
in detached mode (nohup). It handles process execution, output capture,
and maintains process state in the workspace directory.

Arguments:
  WORKSPACE_TIMESTAMP  The timestamp identifier of the workspace
  PROCESS_HASH        The hash identifier of the process to execute

This command should not be called directly by users. It is automatically
invoked by the server when executing processes in nohup mode.

Error: accepts 2 arg(s), received 0
Usage:
  mobileshell nohup WORKSPACE_TIMESTAMP PROCESS_HASH [flags]
...
```

## Test plan
- ✅ Manually tested with 0, 1, 2, and 3 arguments
- ✅ All tests passing via `./scripts/test.sh`
- ✅ Verified --help shows the full description

🤖 Generated with [Claude Code](https://claude.com/claude-code)